### PR TITLE
Add the ability to pass a `void* token` object to the system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ address_cache
 /_build/*
 CMakeLists.txt.user
 /out/*
+.idea/
+cmake-build-*/

--- a/apps/abort/main.c
+++ b/apps/abort/main.c
@@ -54,7 +54,7 @@ static bool Target_Server = true;
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)src;
     (void)invoke_id;
@@ -64,7 +64,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     (void)src;
     (void)invoke_id;

--- a/apps/dcc/main.c
+++ b/apps/dcc/main.c
@@ -68,7 +68,8 @@ static bool Error_Detected = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -79,7 +80,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -90,7 +91,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -100,7 +101,7 @@ static void MyRejectHandler(
 }
 
 static void MyDeviceCommunicationControlSimpleAckHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id)
+    BACNET_ADDRESS *src, uint8_t invoke_id, void *token)
 {
     (void)src;
     (void)invoke_id;
@@ -239,7 +240,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         /* at least one second has passed */
         if (current_seconds != last_seconds) {

--- a/apps/epics/main.c
+++ b/apps/epics/main.c
@@ -180,7 +180,8 @@ static bool Optional_Properties = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -198,7 +199,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -221,7 +222,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -244,7 +245,7 @@ static void MyRejectHandler(
 static void MyReadPropertyAckHandler(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data, void *token)
 {
     int len = 0;
     BACNET_READ_ACCESS_DATA *rp_data;
@@ -272,7 +273,7 @@ static void MyReadPropertyAckHandler(uint8_t *service_request,
 static void MyReadPropertyMultipleAckHandler(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data, void *token)
 {
     int len = 0;
     BACNET_READ_ACCESS_DATA *rpm_data;
@@ -1495,7 +1496,7 @@ int main(int argc, char *argv[])
 
                 /* process; normally is some initial error */
                 if (pdu_len) {
-                    npdu_handler(&src, &Rx_Buf[0], pdu_len);
+                    npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
                 }
                 /* will wait until the device is bound, or timeout and quit */
                 found = address_bind_request(
@@ -1573,7 +1574,7 @@ int main(int argc, char *argv[])
 
                 /* process */
                 if (pdu_len) {
-                    npdu_handler(&src, &Rx_Buf[0], pdu_len);
+                    npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
                 }
 
                 if ((Read_Property_Multiple_Data.new_data) &&
@@ -1664,7 +1665,7 @@ int main(int argc, char *argv[])
 
                 /* process */
                 if (pdu_len) {
-                    npdu_handler(&src, &Rx_Buf[0], pdu_len);
+                    npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
                 }
 
                 if ((Read_Property_Multiple_Data.new_data) &&

--- a/apps/error/main.c
+++ b/apps/error/main.c
@@ -56,7 +56,7 @@ static uint16_t Target_Service = SERVICE_CONFIRMED_READ_PROPERTY;
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)src;
     (void)invoke_id;
@@ -66,7 +66,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     (void)src;
     (void)invoke_id;

--- a/apps/getevent/main.c
+++ b/apps/getevent/main.c
@@ -73,7 +73,8 @@ static BACNET_OBJECT_ID LastReceivedObjectIdentifier;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -85,7 +86,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -97,7 +98,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -116,11 +117,12 @@ static void MyRejectHandler(
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 static void My_Get_Event_Ack_Handler(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data, void *token)
 {
     int len = 0;
     int i;
@@ -277,7 +279,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
 
         /* keep track of time for next check */

--- a/apps/iam/main.c
+++ b/apps/iam/main.c
@@ -56,7 +56,7 @@ static int Target_Segmentation = SEGMENTATION_NONE;
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)src;
     (void)invoke_id;
@@ -66,7 +66,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     (void)src;
     (void)invoke_id;

--- a/apps/iamrouter/main.c
+++ b/apps/iamrouter/main.c
@@ -54,7 +54,7 @@ static int Target_Router_Networks[MAX_ROUTER_DNETS] = { -1 };
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -65,7 +65,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;

--- a/apps/readbdt/main.c
+++ b/apps/readbdt/main.c
@@ -61,7 +61,7 @@ static BACNET_IP_ADDRESS Target_BBMD_Address;
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -72,7 +72,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected)
             break;

--- a/apps/readfdt/main.c
+++ b/apps/readfdt/main.c
@@ -61,7 +61,7 @@ static BACNET_IP_ADDRESS Target_BBMD_Address;
 static bool Error_Detected;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -72,7 +72,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected)
             break;

--- a/apps/readfile/main.c
+++ b/apps/readfile/main.c
@@ -68,7 +68,8 @@ static uint8_t Request_Invoke_ID = 0;
 static void Atomic_Read_File_Error_Handler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -80,7 +81,7 @@ static void Atomic_Read_File_Error_Handler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -92,7 +93,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -105,7 +106,7 @@ static void MyRejectHandler(
 static void AtomicReadFileAckHandler(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data, void *token)
 {
     int len = 0;
     int result = 0;
@@ -165,7 +166,7 @@ static void AtomicReadFileAckHandler(uint8_t *service_request,
 }
 
 static void LocalIAmHandler(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     uint32_t device_id = 0;
@@ -319,7 +320,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         /* at least one second has passed */
         if (current_seconds != last_seconds) {

--- a/apps/readprop/main.c
+++ b/apps/readprop/main.c
@@ -71,7 +71,8 @@ static bool Error_Detected = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -83,7 +84,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -95,7 +96,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -115,11 +116,13 @@ static void MyRejectHandler(
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 static void My_Read_Property_Ack_Handler(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data,
+    void *token)
 {
     int len = 0;
     BACNET_READ_PROPERTY_DATA data;
@@ -421,7 +424,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
 
         /* keep track of time for next check */

--- a/apps/readpropm/main.c
+++ b/apps/readpropm/main.c
@@ -70,7 +70,7 @@ static bool Error_Detected = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -82,7 +82,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -94,7 +94,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     if (address_match(&Target_Address, src) &&
@@ -115,11 +115,12 @@ static void MyRejectHandler(
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 static void My_Read_Property_Multiple_Ack_Handler(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data, void *token)
 {
     int len = 0;
     BACNET_READ_ACCESS_DATA *rpm_data;
@@ -479,7 +480,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
 
         /* keep track of time for next check */

--- a/apps/readrange/main.c
+++ b/apps/readrange/main.c
@@ -74,7 +74,8 @@ static BACNET_READ_RANGE_DATA RR_Request;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -86,7 +87,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -98,7 +99,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -376,7 +377,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
 
         /* keep track of time for next check */

--- a/apps/reinit/main.c
+++ b/apps/reinit/main.c
@@ -65,7 +65,8 @@ static bool Error_Detected = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -76,7 +77,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -87,7 +88,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -97,7 +98,7 @@ static void MyRejectHandler(
 }
 
 static void MyReinitializeDeviceSimpleAckHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id)
+    BACNET_ADDRESS *src, uint8_t invoke_id, void *token)
 {
     (void)src;
     (void)invoke_id;
@@ -200,7 +201,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         /* at least one second has passed */
         if (current_seconds != last_seconds) {

--- a/apps/scov/main.c
+++ b/apps/scov/main.c
@@ -76,7 +76,8 @@ static bool Cancel_Requested = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -88,7 +89,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -100,7 +101,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -111,21 +112,22 @@ static void MyRejectHandler(
 }
 
 static void My_Unconfirmed_COV_Notification_Handler(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
-    handler_ucov_notification(service_request, service_len, src);
+    handler_ucov_notification(service_request, service_len, src, token);
 }
 
 static void My_Confirmed_COV_Notification_Handler(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
-    handler_ccov_notification(service_request, service_len, src, service_data);
+    handler_ccov_notification(service_request, service_len, src, service_data, token);
 }
 
 static void MyWritePropertySimpleAckHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id)
+    BACNET_ADDRESS *src, uint8_t invoke_id, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -408,7 +410,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected) {
             break;

--- a/apps/server/main.c
+++ b/apps/server/main.c
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         /* at least one second has passed */
         elapsed_seconds = (uint32_t)(current_seconds - last_seconds);

--- a/apps/timesync/main.c
+++ b/apps/timesync/main.c
@@ -55,7 +55,7 @@ static uint8_t Rx_Buf[MAX_MPDU] = { 0 };
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -66,7 +66,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected)
             break;

--- a/apps/uptransfer/main.c
+++ b/apps/uptransfer/main.c
@@ -80,7 +80,8 @@ static bool Error_Detected = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -92,7 +93,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -104,7 +105,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -351,7 +352,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected) {
             break;

--- a/apps/whohas/main.c
+++ b/apps/whohas/main.c
@@ -63,7 +63,8 @@ static int32_t Target_Object_Instance_Max = -1;
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server,
+    void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -74,7 +75,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -239,7 +240,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected)
             break;

--- a/apps/whois/main.c
+++ b/apps/whois/main.c
@@ -120,7 +120,7 @@ static void address_table_add(
 }
 
 static void my_i_am_handler(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     uint32_t device_id = 0;
@@ -164,7 +164,7 @@ static void my_i_am_handler(
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -176,7 +176,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -460,7 +460,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected)
             break;

--- a/apps/whoisrouter/main.c
+++ b/apps/whoisrouter/main.c
@@ -56,7 +56,8 @@ static BACNET_ADDRESS Target_Router_Address;
 static bool Error_Detected = false;
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server,
+    void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -67,7 +68,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     (void)src;
@@ -79,7 +80,8 @@ static void MyRejectHandler(
 static void My_Router_Handler(BACNET_ADDRESS *src,
     BACNET_NPDU_DATA *npdu_data,
     uint8_t *npdu, /* PDU data */
-    uint16_t npdu_len)
+    uint16_t npdu_len,
+    void *token)
 {
     uint16_t npdu_offset = 0;
     uint16_t dnet = 0;
@@ -126,7 +128,8 @@ static void My_Router_Handler(BACNET_ADDRESS *src,
 
 static void My_NPDU_Handler(BACNET_ADDRESS *src, /* source address */
     uint8_t *pdu, /* PDU data */
-    uint16_t pdu_len)
+    uint16_t pdu_len,
+    void *token)
 { /* length PDU  */
     int apdu_offset = 0;
     BACNET_ADDRESS dest = { 0 };
@@ -135,7 +138,7 @@ static void My_NPDU_Handler(BACNET_ADDRESS *src, /* source address */
     apdu_offset = npdu_decode(&pdu[0], &dest, src, &npdu_data);
     if (npdu_data.network_layer_message) {
         My_Router_Handler(src, &npdu_data, &pdu[apdu_offset],
-            (uint16_t)(pdu_len - apdu_offset));
+            (uint16_t)(pdu_len - apdu_offset), NULL);
     } else if ((apdu_offset > 0) && (apdu_offset <= pdu_len)) {
         if ((npdu_data.protocol_version == BACNET_PROTOCOL_VERSION) &&
             ((dest.net == 0) || (dest.net == BACNET_BROADCAST_NETWORK))) {
@@ -143,7 +146,7 @@ static void My_NPDU_Handler(BACNET_ADDRESS *src, /* source address */
             /* and we are not a router, so ignore messages with
                routing information cause they are not for us */
             apdu_handler(
-                src, &pdu[apdu_offset], (uint16_t)(pdu_len - apdu_offset));
+                src, &pdu[apdu_offset], (uint16_t)(pdu_len - apdu_offset), NULL);
         } else {
             if (dest.net) {
                 debug_printf("NPDU: DNET=%d.  Discarded!\n", dest.net);
@@ -289,7 +292,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            My_NPDU_Handler(&src, &Rx_Buf[0], pdu_len);
+            My_NPDU_Handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         if (Error_Detected)
             break;

--- a/apps/writefile/main.c
+++ b/apps/writefile/main.c
@@ -67,7 +67,8 @@ static uint8_t Current_Invoke_ID = 0;
 static void Atomic_Write_File_Error_Handler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Current_Invoke_ID)) {
@@ -79,7 +80,7 @@ static void Atomic_Write_File_Error_Handler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -91,7 +92,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Current_Invoke_ID)) {
@@ -102,7 +103,7 @@ static void MyRejectHandler(
 }
 
 static void LocalIAmHandler(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     uint32_t device_id = 0;
@@ -218,7 +219,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
         /* at least one second has passed */
         if (current_seconds != last_seconds) {

--- a/apps/writeprop/main.c
+++ b/apps/writeprop/main.c
@@ -82,7 +82,7 @@ static bool Error_Detected = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -94,7 +94,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -106,7 +106,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -117,7 +117,7 @@ static void MyRejectHandler(
 }
 
 static void MyWritePropertySimpleAckHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id)
+    BACNET_ADDRESS *src, uint8_t invoke_id, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -426,7 +426,7 @@ int main(int argc, char *argv[])
 
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
 
         /* keep track of time for next check */

--- a/apps/writepropm/main.c
+++ b/apps/writepropm/main.c
@@ -73,7 +73,8 @@ static bool Verbose = false;
 static void MyErrorHandler(BACNET_ADDRESS *src,
     uint8_t invoke_id,
     BACNET_ERROR_CLASS error_class,
-    BACNET_ERROR_CODE error_code)
+    BACNET_ERROR_CODE error_code,
+    void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -86,7 +87,7 @@ static void MyErrorHandler(BACNET_ADDRESS *src,
 }
 
 static void MyAbortHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t abort_reason, bool server, void *token)
 {
     (void)server;
     if (address_match(&Target_Address, src) &&
@@ -98,7 +99,7 @@ static void MyAbortHandler(
 }
 
 static void MyRejectHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason)
+    BACNET_ADDRESS *src, uint8_t invoke_id, uint8_t reject_reason, void *token)
 {
     /* FIXME: verify src and invoke id */
     if (address_match(&Target_Address, src) &&
@@ -110,7 +111,7 @@ static void MyRejectHandler(
 }
 
 static void MyWritePropertyMultipleSimpleAckHandler(
-    BACNET_ADDRESS *src, uint8_t invoke_id)
+    BACNET_ADDRESS *src, uint8_t invoke_id, void *token)
 {
     if (address_match(&Target_Address, src) &&
         (invoke_id == Request_Invoke_ID)) {
@@ -504,7 +505,7 @@ int main(int argc, char *argv[])
         pdu_len = datalink_receive(&src, &Rx_Buf[0], MAX_MPDU, timeout);
         /* process */
         if (pdu_len) {
-            npdu_handler(&src, &Rx_Buf[0], pdu_len);
+            npdu_handler(&src, &Rx_Buf[0], pdu_len, NULL);
         }
 
         /* keep track of time for next check */

--- a/ports/atmega168/h_whois.c
+++ b/ports/atmega168/h_whois.c
@@ -40,7 +40,7 @@
 bool Send_I_Am_Flag = true;
 
 void handler_who_is(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     int32_t low_limit = 0;

--- a/src/bacnet/basic/npdu/h_npdu.c
+++ b/src/bacnet/basic/npdu/h_npdu.c
@@ -61,10 +61,12 @@
  *                   already been sent via the apdu_handler.
  *  @param pdu [in]  Buffer containing the NPDU and APDU of the received packet.
  *  @param pdu_len [in] The size of the received message in the pdu[] buffer.
+ *  @param token [in] The caller token, passed back in callbacks.
  */
 void npdu_handler(BACNET_ADDRESS *src, /* source address */
     uint8_t *pdu, /* PDU data */
-    uint16_t pdu_len)
+    uint16_t pdu_len,
+    void *token)
 { /* length PDU  */
     int apdu_offset = 0;
     BACNET_ADDRESS dest = { 0 };
@@ -96,7 +98,7 @@ void npdu_handler(BACNET_ADDRESS *src, /* source address */
                     /* then enter IDLE - ignore the PDU */
                 } else {
                     apdu_handler(src, &pdu[apdu_offset],
-                        (uint16_t)(pdu_len - apdu_offset));
+                        (uint16_t)(pdu_len - apdu_offset), token);
                 }
             } else {
 #if PRINT_ENABLED

--- a/src/bacnet/basic/npdu/h_npdu.h
+++ b/src/bacnet/basic/npdu/h_npdu.h
@@ -46,7 +46,8 @@ extern "C" {
     void npdu_handler(
         BACNET_ADDRESS * src,
         uint8_t * pdu,
-        uint16_t pdu_len);
+        uint16_t pdu_len,
+        void * token);
     BACNET_STACK_EXPORT
     void npdu_handler_cleanup(void);
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/npdu/h_routed_npdu.h
+++ b/src/bacnet/basic/npdu/h_routed_npdu.h
@@ -46,7 +46,8 @@ extern "C" {
         BACNET_ADDRESS * src,
         int *DNET_list,
         uint8_t * pdu,
-        uint16_t pdu_len);
+        uint16_t pdu_len,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_apdu.h
+++ b/src/bacnet/basic/service/h_apdu.h
@@ -49,7 +49,8 @@ extern "C" {
         *unconfirmed_function) (
         uint8_t * service_request,
         uint16_t len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
 /* generic confirmed function handler */
 /* Suitable to handle the following services: */
@@ -72,13 +73,15 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
 
 /* generic confirmed simple ack function handler */
     typedef void (
         *confirmed_simple_ack_function) (
         BACNET_ADDRESS * src,
-        uint8_t invoke_id);
+        uint8_t invoke_id,
+        void * token);
 
 /* generic confirmed ack function handler */
     typedef void (
@@ -86,7 +89,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_ACK_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_ACK_DATA * service_data,
+        void * token);
 
 /* generic error reply function */
     typedef void (
@@ -94,7 +98,8 @@ extern "C" {
         BACNET_ADDRESS * src,
         uint8_t invoke_id,
         BACNET_ERROR_CLASS error_class,
-        BACNET_ERROR_CODE error_code);
+        BACNET_ERROR_CODE error_code,
+        void * token);
 
 /* generic abort reply function */
     typedef void (
@@ -102,14 +107,16 @@ extern "C" {
         BACNET_ADDRESS * src,
         uint8_t invoke_id,
         uint8_t abort_reason,
-        bool server);
+        bool server,
+        void * token);
 
 /* generic reject reply function */
     typedef void (
         *reject_function) (
         BACNET_ADDRESS * src,
         uint8_t invoke_id,
-        uint8_t reject_reason);
+        uint8_t reject_reason,
+        void * token);
 
     BACNET_STACK_EXPORT
     void apdu_set_confirmed_ack_handler(
@@ -190,7 +197,9 @@ extern "C" {
     void apdu_handler(
         BACNET_ADDRESS * src,   /* source address */
         uint8_t * apdu, /* APDU data */
-        uint16_t pdu_len);      /* for confirmed messages */
+        uint16_t pdu_len,
+        void * token /* pased back to callback */
+        );      /* for confirmed messages */
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_ccov.c
+++ b/src/bacnet/basic/service/h_ccov.c
@@ -59,11 +59,13 @@
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_ccov_notification(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     BACNET_NPDU_DATA npdu_data;
     BACNET_COV_DATA cov_data;

--- a/src/bacnet/basic/service/h_ccov.h
+++ b/src/bacnet/basic/service/h_ccov.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_cov.c
+++ b/src/bacnet/basic/service/h_cov.c
@@ -771,11 +771,13 @@ static bool cov_subscribe(BACNET_ADDRESS *src,
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_cov_subscribe(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     BACNET_SUBSCRIBE_COV_DATA cov_data;
     int len = 0;

--- a/src/bacnet/basic/service/h_cov.h
+++ b/src/bacnet/basic/service/h_cov.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
     BACNET_STACK_EXPORT
     bool handler_cov_fsm(
         void);

--- a/src/bacnet/basic/service/h_dcc.c
+++ b/src/bacnet/basic/service/h_dcc.c
@@ -94,11 +94,13 @@ char *handler_dcc_password(void)
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_device_communication_control(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     uint16_t timeDuration = 0;
     BACNET_COMMUNICATION_ENABLE_DISABLE state = COMMUNICATION_ENABLE;

--- a/src/bacnet/basic/service/h_dcc.h
+++ b/src/bacnet/basic/service/h_dcc.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
     BACNET_STACK_EXPORT
     void handler_dcc_password_set(
         char *new_password);

--- a/src/bacnet/basic/service/h_getevent.c
+++ b/src/bacnet/basic/service/h_getevent.c
@@ -77,7 +77,8 @@ void handler_get_event_information_set(
 void handler_get_event_information(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     int len = 0;
     int pdu_len = 0;

--- a/src/bacnet/basic/service/h_getevent.h
+++ b/src/bacnet/basic/service/h_getevent.h
@@ -53,7 +53,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void *token);
 
     BACNET_STACK_EXPORT
     void ge_ack_print_data(BACNET_GET_EVENT_INFORMATION_DATA* data,

--- a/src/bacnet/basic/service/h_iam.c
+++ b/src/bacnet/basic/service/h_iam.c
@@ -41,9 +41,10 @@
  * @param service_request [in] The received message to be handled.
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_i_am_add(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     uint32_t device_id = 0;
@@ -80,9 +81,10 @@ void handler_i_am_add(
  * @param service_request [in] The received message to be handled.
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_i_am_bind(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     uint32_t device_id = 0;

--- a/src/bacnet/basic/service/h_iam.h
+++ b/src/bacnet/basic/service/h_iam.h
@@ -45,13 +45,15 @@ extern "C" {
     void handler_i_am_add(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
     BACNET_STACK_EXPORT
     void handler_i_am_bind(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_ihave.c
+++ b/src/bacnet/basic/service/h_ihave.c
@@ -40,9 +40,10 @@
  * @param service_request [in] The received message to be handled.
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_i_have(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     BACNET_I_HAVE_DATA data;

--- a/src/bacnet/basic/service/h_ihave.h
+++ b/src/bacnet/basic/service/h_ihave.h
@@ -45,7 +45,8 @@ extern "C" {
     void handler_i_have(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_noserv.c
+++ b/src/bacnet/basic/service/h_noserv.c
@@ -50,11 +50,13 @@
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_unrecognized_service(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     int len = 0;
     int pdu_len = 0;

--- a/src/bacnet/basic/service/h_noserv.h
+++ b/src/bacnet/basic/service/h_noserv.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * dest,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_rd.c
+++ b/src/bacnet/basic/service/h_rd.c
@@ -63,11 +63,13 @@
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_reinitialize_device(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     BACNET_REINITIALIZE_DEVICE_DATA rd_data;
     int len = 0;

--- a/src/bacnet/basic/service/h_rd.h
+++ b/src/bacnet/basic/service/h_rd.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void *token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_rp.c
+++ b/src/bacnet/basic/service/h_rp.c
@@ -63,11 +63,13 @@
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_read_property(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     BACNET_READ_PROPERTY_DATA rpdata;
     int len = 0;

--- a/src/bacnet/basic/service/h_rp.h
+++ b/src/bacnet/basic/service/h_rp.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_rpm.c
+++ b/src/bacnet/basic/service/h_rpm.c
@@ -176,11 +176,13 @@ static int RPM_Encode_Property(
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_read_property_multiple(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     bool berror = false;
     int len = 0;

--- a/src/bacnet/basic/service/h_rpm.h
+++ b/src/bacnet/basic/service/h_rpm.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_rr.c
+++ b/src/bacnet/basic/service/h_rr.c
@@ -102,7 +102,8 @@ static int Encode_RR_payload(uint8_t *apdu, BACNET_READ_RANGE_DATA *pRequest)
 void handler_read_range(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     BACNET_READ_RANGE_DATA data;
     int len = 0;

--- a/src/bacnet/basic/service/h_rr.h
+++ b/src/bacnet/basic/service/h_rr.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_rr_a.c
+++ b/src/bacnet/basic/service/h_rr_a.c
@@ -103,7 +103,8 @@ static void PrintReadRangeData(BACNET_READ_RANGE_DATA *data)
 void handler_read_range_ack(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_ACK_DATA *service_data,
+    void *token)
 {
     int len = 0;
     BACNET_READ_RANGE_DATA data;

--- a/src/bacnet/basic/service/h_rr_a.h
+++ b/src/bacnet/basic/service/h_rr_a.h
@@ -46,7 +46,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_ACK_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_ACK_DATA * service_data,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_ts.c
+++ b/src/bacnet/basic/service/h_ts.c
@@ -66,7 +66,7 @@ static void show_bacnet_date_time(BACNET_DATE *bdate, BACNET_TIME *btime)
 #endif
 
 void handler_timesync(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     BACNET_DATE bdate = { 0 };
@@ -93,7 +93,7 @@ void handler_timesync(
 }
 
 void handler_timesync_utc(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     BACNET_DATE bdate;

--- a/src/bacnet/basic/service/h_ts.h
+++ b/src/bacnet/basic/service/h_ts.h
@@ -48,24 +48,27 @@ extern "C" {
     void handler_timesync(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
     BACNET_STACK_EXPORT
     void handler_timesync_utc(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
     /* time sync master features */
     BACNET_STACK_EXPORT
     int handler_timesync_encode_recipients(
         uint8_t * apdu,
-        int max_apdu);
+        int max_apdu,
+        void * token);
     BACNET_STACK_EXPORT
     void handler_timesync_task(BACNET_DATE_TIME *bdatetime);
     BACNET_STACK_EXPORT
     void handler_timesync_init(void);
     BACNET_STACK_EXPORT
     bool handler_timesync_recipient_write(
-        BACNET_WRITE_PROPERTY_DATA * wp_data);
+        BACNET_WRITE_PROPERTY_DATA * wp_data, void * token);
     BACNET_STACK_EXPORT
     uint32_t handler_timesync_interval(void);
     BACNET_STACK_EXPORT

--- a/src/bacnet/basic/service/h_ucov.c
+++ b/src/bacnet/basic/service/h_ucov.c
@@ -55,9 +55,10 @@
  * @param service_request [in] The contents of the service request.
  * @param service_len [in] The length of the service_request.
  * @param src [in] BACNET_ADDRESS of the source of the message (unused)
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_ucov_notification(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     BACNET_COV_DATA cov_data;
     BACNET_PROPERTY_VALUE property_value[MAX_COV_PROPERTIES];

--- a/src/bacnet/basic/service/h_ucov.h
+++ b/src/bacnet/basic/service/h_ucov.h
@@ -45,7 +45,8 @@ extern "C" {
     void handler_ucov_notification(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_upt.c
+++ b/src/bacnet/basic/service/h_upt.c
@@ -106,7 +106,7 @@ void private_transfer_print_data(BACNET_PRIVATE_TRANSFER_DATA *private_data)
 }
 
 void handler_unconfirmed_private_transfer(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     BACNET_PRIVATE_TRANSFER_DATA private_data;
     int len = 0;

--- a/src/bacnet/basic/service/h_upt.h
+++ b/src/bacnet/basic/service/h_upt.h
@@ -46,7 +46,8 @@ extern "C" {
     void handler_unconfirmed_private_transfer(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void *token);
     BACNET_STACK_EXPORT
     void private_transfer_print_data(
         BACNET_PRIVATE_TRANSFER_DATA *private_data);

--- a/src/bacnet/basic/service/h_whohas.c
+++ b/src/bacnet/basic/service/h_whohas.c
@@ -80,9 +80,10 @@ static void match_name_or_object(BACNET_WHO_HAS_DATA *data)
  * @param service_request [in] The received message to be handled.
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_who_has(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     BACNET_WHO_HAS_DATA data;
@@ -120,9 +121,10 @@ void handler_who_has(
  * @param service_request [in] The received message to be handled.
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source (ignored).
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_who_has_for_routing(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     BACNET_WHO_HAS_DATA data;

--- a/src/bacnet/basic/service/h_whohas.h
+++ b/src/bacnet/basic/service/h_whohas.h
@@ -45,13 +45,15 @@ extern "C" {
     void handler_who_has(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
     BACNET_STACK_EXPORT
     void handler_who_has_for_routing(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_whois.c
+++ b/src/bacnet/basic/service/h_whois.c
@@ -43,9 +43,10 @@
  * @param service_request [in] The received message to be handled.
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source (ignored).
+ * @param token [in] The caller token, passed back in callbacks.
  */
 void handler_who_is(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     int32_t low_limit = 0;
@@ -74,9 +75,11 @@ void handler_who_is(
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source that the
  *                 response will be sent back to.
+ * @param token [in] The caller token, passed back in callbacks.
+ *
  */
 void handler_who_is_unicast(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     int len = 0;
     int32_t low_limit = 0;
@@ -162,9 +165,10 @@ static void check_who_is_for_routing(uint8_t *service_request,
  * @param service_request [in] The received message to be handled.
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source (ignored).
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_who_is_bcast_for_routing(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     check_who_is_for_routing(service_request, service_len, src, false);
 }
@@ -179,9 +183,10 @@ void handler_who_is_bcast_for_routing(
  * @param service_len [in] Length of the service_request message.
  * @param src [in] The BACNET_ADDRESS of the message's source that the
  *                 response will be sent back to.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_who_is_unicast_for_routing(
-    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src)
+    uint8_t *service_request, uint16_t service_len, BACNET_ADDRESS *src, void *token)
 {
     check_who_is_for_routing(service_request, service_len, src, true);
 }

--- a/src/bacnet/basic/service/h_whois.h
+++ b/src/bacnet/basic/service/h_whois.h
@@ -45,25 +45,29 @@ extern "C" {
     void handler_who_is(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
     BACNET_STACK_EXPORT
     void handler_who_is_unicast(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
     BACNET_STACK_EXPORT
     void handler_who_is_bcast_for_routing(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
     BACNET_STACK_EXPORT
     void handler_who_is_unicast_for_routing(
         uint8_t * service_request,
         uint16_t service_len,
-        BACNET_ADDRESS * src);
+        BACNET_ADDRESS * src,
+        void * token);
 
 #ifdef __cplusplus
 }

--- a/src/bacnet/basic/service/h_wp.c
+++ b/src/bacnet/basic/service/h_wp.c
@@ -60,11 +60,13 @@
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_write_property(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     BACNET_WRITE_PROPERTY_DATA wp_data;
     int len = 0;

--- a/src/bacnet/basic/service/h_wp.h
+++ b/src/bacnet/basic/service/h_wp.h
@@ -47,7 +47,7 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data, void * token);
 
     BACNET_STACK_EXPORT
     bool WPValidateString(

--- a/src/bacnet/basic/service/h_wpm.c
+++ b/src/bacnet/basic/service/h_wpm.c
@@ -61,11 +61,13 @@
  * @param src [in] BACNET_ADDRESS of the source of the message
  * @param service_data [in] The BACNET_CONFIRMED_SERVICE_DATA information
  *                          decoded from the APDU header of this message.
+ * @param token [in] The caller token, passed back in callbacks (ignored).
  */
 void handler_write_property_multiple(uint8_t *service_request,
     uint16_t service_len,
     BACNET_ADDRESS *src,
-    BACNET_CONFIRMED_SERVICE_DATA *service_data)
+    BACNET_CONFIRMED_SERVICE_DATA *service_data,
+    void *token)
 {
     int len = 0;
     int apdu_len = 0;

--- a/src/bacnet/basic/service/h_wpm.h
+++ b/src/bacnet/basic/service/h_wpm.h
@@ -47,7 +47,8 @@ extern "C" {
         uint8_t * service_request,
         uint16_t service_len,
         BACNET_ADDRESS * src,
-        BACNET_CONFIRMED_SERVICE_DATA * service_data);
+        BACNET_CONFIRMED_SERVICE_DATA * service_data,
+        void * token);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
such that this token is passed back to registered callbacks.
It is a no-op for existing code.

This will allow use of bacnet-stack from c++, where member functions
cannot be passed, but context could be needed for handling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palindromicity/bacnet-stack/1)
<!-- Reviewable:end -->
